### PR TITLE
Build multi-arch images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v1
       - name: build
         run: make build
       - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: setup buildx
-        uses: docker/setup-buildx-action@v1
       - name: build
         run: make build
       - name: test

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -2,8 +2,7 @@ name: Latest
 on:
   push:
     branches:
-#      - master
-      - docker-buildx
+      - master
 
 jobs:
   release:
@@ -17,11 +16,11 @@ jobs:
         run: make build_latest
       - name: test latest
         run: make test_latest
-      - name: setup QEMU (to run builders other than host)
+      - name: setup qemu (to run builders other than host)
         uses: docker/setup-qemu-action@master
         with:
           platforms: all
-      - name: setup buildx
+      - name: setup buildx (used by our 'release_latest' makefile target for multi-arch releases)
         id: buildx
         uses: docker/setup-buildx-action@master
       - name: login to docker hub

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - name: install buildx
+        uses: docker/setup-buildx-action@v1
       - name: build latest
         run: make build_latest
       - name: test latest

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -17,6 +17,13 @@ jobs:
         run: make build_latest
       - name: test latest
         run: make test_latest
+      - name: setup QEMU (to run builders other than host)
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: setup buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
       - name: login to docker hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: install buildx
+      - name: setup buildx
         uses: docker/setup-buildx-action@v1
       - name: build latest
         run: make build_latest

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -2,7 +2,8 @@ name: Latest
 on:
   push:
     branches:
-      - master
+#      - master
+      - docker-buildx
 
 jobs:
   release:
@@ -12,8 +13,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: setup buildx
-        uses: docker/setup-buildx-action@v1
       - name: build latest
         run: make build_latest
       - name: test latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - name: install buildx
+        uses: docker/setup-buildx-action@v1
       - name: extract tag for release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
       - name: build all image variants

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: install buildx
+      - name: setup buildx
         uses: docker/setup-buildx-action@v1
       - name: extract tag for release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: setup buildx
-        uses: docker/setup-buildx-action@v1
       - name: extract tag for release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
       - name: build all image variants

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,13 @@ jobs:
         run: make build VERSION=$RELEASE_VERSION
       - name: test all image variants
         run: make test VERSION=$RELEASE_VERSION
+      - name: setup qemu (to run builders other than host)
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: setup buildx (used by our 'release' makefile target for multi-arch releases)
+        id: buildx
+        uses: docker/setup-buildx-action@master
       - name: login to docker hub
         uses: docker/login-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ build: TAG=${VERSION}
 build:
 	@echo -e "\n[${COLOR_BLUE}build${COLOR_RESET}/${COLOR_TEAL}${TAG}${COLOR_RESET}] ${COLOR_ORANGE}Building image${COLOR_RESET}..."
 	@docker build -t ${IMAGE}:${TAG} -t ${IMAGE}:$(shell echo ${TAG} | rev | cut -d '.' -f2- | rev ) .
-	@docker buildx ls
 build_latest:
 	@echo -e "\n[${COLOR_BLUE}build${COLOR_RESET}/${COLOR_TEAL}latest${COLOR_RESET}] ${COLOR_ORANGE}Building image${COLOR_RESET}..."
 	@docker build -t ${IMAGE} .

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ build: TAG=${VERSION}
 build:
 	@echo -e "\n[${COLOR_BLUE}build${COLOR_RESET}/${COLOR_TEAL}${TAG}${COLOR_RESET}] ${COLOR_ORANGE}Building image${COLOR_RESET}..."
 	@docker build -t ${IMAGE}:${TAG} -t ${IMAGE}:$(shell echo ${TAG} | rev | cut -d '.' -f2- | rev ) .
+	@docker buildx ls
 build_latest:
 	@echo -e "\n[${COLOR_BLUE}build${COLOR_RESET}/${COLOR_TEAL}latest${COLOR_RESET}] ${COLOR_ORANGE}Building image${COLOR_RESET}..."
 	@docker build -t ${IMAGE} .
@@ -64,5 +65,7 @@ release: TAG=${VERSION}
 release_latest: TAG=latest
 release release_latest:
 	@echo -e "\n[${COLOR_BLUE}release${COLOR_RESET}/${COLOR_TEAL}${TAG}${COLOR_RESET}] ${COLOR_ORANGE}Pushing image${COLOR_RESET}..."
-	@docker push ${IMAGE}:${TAG}
-	@docker push ${IMAGE}:$(shell echo ${TAG} | rev | cut -d '.' -f2- | rev )
+	@docker buildx create --name http-resource-builder
+	@docker buildx build --builder http-resource-builder --platform linux/amd64,linux/arm64/v8 --push --tag ${IMAGE}:$(shell echo ${TAG} | rev | cut -d '.' -f2- | rev ) .
+	@docker buildx build --builder http-resource-builder --platform linux/amd64,linux/arm64/v8 --push --tag ${IMAGE}:${TAG} .
+	@docker buildx rm http-resource-builder


### PR DESCRIPTION
Added `buildx` to all CI builds (latest and release) so we always build multi-arch images.