### PR TITLE
Add data_binary options

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,6 +73,7 @@ Options are:
 
 * `out_only`: _Optional._  Disables the `check` and `in` operations, turning them into no-ops (including the implicit `get` after each `put`).
 Relevant for scenarios where you are _only_ using `put` operations, or for any other reason you do not want to regularly check the endpoint.  Default is `false`.
+* `data_binary`: _Optional._  Post data file using `put` operations in binary mode. Applied for both source and params file options. Default is `false`.
 * `sensitive`: _Optional._  If `true`, the responses from the endpoint will be considered sensitive and not show up in the logs or Concourse UI.  Can be overridden as a param to each `get` or `put` step. Default is `false`.
 
 == Behavior

--- a/assets/common
+++ b/assets/common
@@ -144,6 +144,7 @@ source_version_jq=$(jq -r '.source.version.jq // ""' < $payload)
 source_version_hash=$(jq -r '.source.version.hash // ""' < $payload)
 source_version_default=$(jq -r '.source.version.default // ""' < $payload)
 source_out_only=$(jq -r '.source.out_only // false' < $payload)
+source_data_binary=$(jq -r '.source.data_binary // false' < $payload)
 
 # params config
 params_method=$(jq -r '.params.method // ""' < $payload)

--- a/assets/curlops
+++ b/assets/curlops
@@ -57,12 +57,20 @@ invokeCurl() {
     exit 1
   elif isSet params_file; then
     replaceBuildMetadataInFile "$params_file"
-    expanded_data+=("-d" "@$params_file")
+    if isTrue source_data_binary; then
+      expanded_data+=("--data-binary" "@$params_file")
+    else
+      expanded_data+=("-d" "@$params_file")
+    fi
   elif isSet params_text; then
     expanded_data+=("-d" "$(replaceBuildMetadata "$params_text")")
   elif isSet source_file; then
     replaceBuildMetadataInFile "$source_file"
-    expanded_data+=("-d" "@$source_file")
+    if isTrue source_data_binary; then
+      expanded_data+=("--data-binary" "@$source_file")
+    else
+      expanded_data+=("-d" "@$source_file")
+    fi
   elif isSet source_text; then
     expanded_data+=("-d" "$(replaceBuildMetadata "$source_text")")
   fi


### PR DESCRIPTION
I use http-resource to post json to a REST API. It works. 
I try to do the same with yaml. It doesn't work, because breaks line are suppressed. 
To make it it neccesary to use --data_binary curl option. 