### PR TITLE
Add test coverage for data file usage

### DIFF
--- a/test/fixtures/stdin-source-data-file.json
+++ b/test/fixtures/stdin-source-data-file.json
@@ -1,0 +1,5 @@
+{
+  "source": {
+    "file": "some-dir/some-source-file.json"
+  }
+}

--- a/test/fixtures/stdin-source-params-data-file-override.json
+++ b/test/fixtures/stdin-source-params-data-file-override.json
@@ -1,0 +1,8 @@
+{
+  "source": {
+    "file": "some-dir/some-source-file.json"
+  },
+  "params": {
+    "file": "some-dir/some-params-file.json"
+  }
+}

--- a/test/fixtures/stdin-source-params-data-file.json
+++ b/test/fixtures/stdin-source-params-data-file.json
@@ -1,0 +1,5 @@
+{
+  "params": {
+    "file": "some-dir/some-params-file.json"
+  }
+}

--- a/test/out.bats
+++ b/test/out.bats
@@ -21,6 +21,9 @@ source_out() {
     log() { :; }
     export -f log
 
+    # stub the build metadata replacements (can't easily mock this with tmp files since source config doesn't point to a tmp file)
+    replaceBuildMetadataInFile() { :; }
+
     # create some tmp files
     request_headers="$BATS_TEST_TMPDIR/request_headers"
     response_headers="$BATS_TEST_TMPDIR/response_headers"
@@ -120,6 +123,17 @@ teardown() {
     assert_equal $(cat $request_headers | sed -n -e "/^Param-Header:/p" | cut -d':' -f2-) 'param-value'
 }
 
+@test "[out] invokes endpoint with source data file" {
+    source_out "stdin-source-data-file"
+
+    target_dir=$BATS_TEST_TMPDIR
+
+    putResource
+
+    assert_equal "${expanded_data[0]}" "-d"
+    assert_equal "${expanded_data[1]}" "@some-dir/some-source-file.json"
+}
+
 @test "[out] invokes endpoint with source data text" {
     source_out "stdin-source-data-text"
 
@@ -129,6 +143,28 @@ teardown() {
 
     assert_equal "${expanded_data[0]}" "-d"
     assert_equal "${expanded_data[1]}" "some-source-data"
+}
+
+@test "[out] invokes endpoint with param data file" {
+    source_out "stdin-source-params-data-file"
+
+    target_dir=$BATS_TEST_TMPDIR
+
+    putResource
+
+    assert_equal "${expanded_data[0]}" "-d"
+    assert_equal "${expanded_data[1]}" "@some-dir/some-params-file.json"
+}
+
+@test "[out] invokes endpoint with param data file (overrides source data)" {
+    source_out "stdin-source-params-data-file-override"
+
+    target_dir=$BATS_TEST_TMPDIR
+
+    putResource
+
+    assert_equal "${expanded_data[0]}" "-d"
+    assert_equal "${expanded_data[1]}" "@some-dir/some-params-file.json"
 }
 
 @test "[out] invokes endpoint with param data text" {


### PR DESCRIPTION
Added test coverage for `out` operations that use a data file in the
`curl` request (`-d`).

This required stubbing out the `replaceBuildMetadataInFile()` method
due to the difficulty of trying to mock this behavior with a real file.
We would have had to coordinate the test config fixture with the
`$BATS_TEST_TMPDIR` location and that would be more effort
(and confusion) than the test is currently worth.

But these new tests at least give us coverage to assert we use the data
file config if/when it is configured in either the `source` or as a step
`params`.