### PR TITLE
Support HEAD method by implicitly including '--head' option

### DIFF
--- a/assets/curlops
+++ b/assets/curlops
@@ -86,6 +86,10 @@ invokeCurl() {
     expanded_options+=("--insecure")
   fi
 
+  if [ "${method^^}" == "HEAD" ]; then
+    expanded_options+=("--head")
+  fi
+
   log -p "\n--> invoking ${yellow}${method}${reset} ${blue}${source_url}${reset} ..."
   log "headers: ${expanded_headers[*]}"
   log "data: ${expanded_data[*]}"

--- a/test/check.bats
+++ b/test/check.bats
@@ -331,3 +331,19 @@ teardown() {
     # should emit an empty version list
     assert_equal $(jq length <<< "$output") 0
 }
+
+@test "[check] (gh-8) includes option '--head' when method is HEAD" {
+    source_check "stdin-source-method-head"
+
+    checkResource
+
+    assert_equal "${expanded_options[0]}" "--head"
+}
+
+@test "[check] (gh-8) includes option '--head' when method is HEAD (case insensitive)" {
+    source_check "stdin-source-method-head-crazycase"
+
+    checkResource
+
+    assert_equal "${expanded_options[0]}" "--head"
+}

--- a/test/fixtures/stdin-source-method-head-crazycase.json
+++ b/test/fixtures/stdin-source-method-head-crazycase.json
@@ -1,0 +1,5 @@
+{
+  "source": {
+    "method": "hEaD"
+  }
+}

--- a/test/fixtures/stdin-source-method-head.json
+++ b/test/fixtures/stdin-source-method-head.json
@@ -1,0 +1,5 @@
+{
+  "source": {
+    "method": "HEAD"
+  }
+}


### PR DESCRIPTION
We use curl under the hood to perform the http invocation.  Curl is
quite particular with the HEAD method (`-X HEAD`) and strongly suggests
you specify the `--head` option.

Attempting without it:

    curl -X HEAD https://www.wikipedia.org
    Warning: Setting custom HTTP method to HEAD with -X/--request may not work the
    Warning: way you want. Consider using -I/--head instead.

This commit adds some special handling that will add the `--head` option
if the method is HEAD (case insensitive).

Closes #8