### PR TITLE
Make build metadata replacements an "opt-in" feature

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,7 @@ source:
 * `text`: _Optional._ Inline text to be sent as the body of the request.  Cannot be specified at the same time as `file`.  Can be overridden as a param to each `get` or `put` step.
 * `data_binary`: _Optional._  Whether to treat the `file` data as binary (rather than plain text).  This has implications on the mode used in the `put` operation _only_.  Can be overridden as a param to each `put` step.  Default is `false`.
 * `build_metadata`: _Optional._  List of component(s) to perform  https://concourse-ci.org/implementing-resource-types.html#resource-metadata[build metadata variable] substitution on.  Can be overridden as a param to each `get` or `put` step.  By default, no substitution is performed on any components.  Valid values include:
-** `headers`: Substitute variables used in the `headers`.
+** `headers`: Substitute any/all variables used in the `headers`.
 +
 [source,yaml]
 ----
@@ -44,7 +44,7 @@ source:
   headers:
     X-Build-Logs: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 ----
-** `body`:  Substitute variables in `file` or `text` content.
+** `body`:  Substitute any/all variables used in `file` or `text` content.
 +
 [source,yaml]
 ----
@@ -76,7 +76,7 @@ jobs:
 +
 **Binary content is never attempted**
 +
-Substitution is also _never_ performed on a `body` whose content is flagged as `data_binary` (regardless of what `build_metadata` says).  For example, the `put` below will _not_ attempt token replacements on the body since `data_binary` is `true`.
+Substitution is also _never_ performed on a `body` whose content is flagged as `data_binary` (regardless of what `build_metadata` says).  For example, the `put` below will _not_ attempt token replacements on the body since `data_binary` is `true` (but will still replace any tokens in the `headers`).
 +
 [source,yaml]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -31,11 +31,68 @@ source:
   headers:
     Accept: application/json
 ----
-* `file`: _Optional._ File containing content to be sent as the body of the request.  Cannot be specified at the same time as `text`.  Can be overridden as a parm to each `get` or `put` step.
-* `text`: _Optional._ Inline text to be sent as the body of the request.  Cannot be specified at the same time as `file`.  Can be overridden as a parm to each `get` or `put` step.
+* `file`: _Optional._ File containing content to be sent as the body of the request.  Cannot be specified at the same time as `text`.  Can be overridden as a param to each `get` or `put` step.
+* `text`: _Optional._ Inline text to be sent as the body of the request.  Cannot be specified at the same time as `file`.  Can be overridden as a param to each `get` or `put` step.
+* `data_binary`: _Optional._  Whether to treat the `file` data as binary (rather than plain text).  This has implications on the mode used in the `put` operation _only_.  Can be overridden as a param to each `put` step.  Default is `false`.
+* `build_metadata`: _Optional._  List of component(s) to perform  https://concourse-ci.org/implementing-resource-types.html#resource-metadata[build metadata variable] substitution on.  Can be overridden as a param to each `get` or `put` step.  By default, no substitution is performed on any components.  Valid values include:
+** `headers`: Substitute variables used in the `headers`.
 +
-TIP: Concourse https://concourse-ci.org/implementing-resource-types.html#resource-metadata[build metadata variables] can be used in both `file` and `text` content, and will be automatically substituted in `get` and `put` steps.
-* `data_binary`: _Optional._  Whether to treat the `file` data as binary (rather than plain text).  This has implications on the mode used in the `put` operation _only_.  Can be overridden as a parm to each `put` step.  Default is `false`.
+[source,yaml]
+----
+source:
+  build_metadata: [headers]
+  headers:
+    X-Build-Logs: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+----
+** `body`:  Substitute variables in `file` or `text` content.
++
+[source,yaml]
+----
+source:
+  build_metadata: [body]
+  text: |
+    See build logs at $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME.
+----
+**Overriding in a step**
++
+Configuring the `build_metadata` in a step completely overrides the source config.  For example,
+the pipeline below will perform token replacements on the headers and body (if configured with one) during the `check` and `get`, but on _neither_ during the `put` step.
++
+[source,yaml]
+----
+resources:
+  - name: my-http-resource
+    type: http-resource
+    source:
+      build_metadata: [headers,body]
+
+jobs:
+  - name: post-something
+    plan:
+      - put: my-http-resource
+        params:
+          build_metadata: []
+----
++
+**Binary content is never attempted**
++
+Substitution is also _never_ performed on a `body` whose content is flagged as `data_binary` (regardless of what `build_metadata` says).  For example, the `put` below will _not_ attempt token replacements on the body since `data_binary` is `true`.
++
+[source,yaml]
+----
+resources:
+  - name: my-http-resource
+    type: http-resource
+    source:
+      build_metadata: [headers,body]
+
+jobs:
+  - name: post-something
+    plan:
+      - put: my-http-resource
+        params:
+          data_binary: true
+----
 
 [#config-source-version]
 * `version`: _Optional_. How to determine the resource's version (see xref:versions[]).  Default is to compute a hash digest of the response body (without the headers).
@@ -109,6 +166,7 @@ General purpose invocation of the `url`, optionally sending a request body.
   plan:
     - put: my-http-resource
       params:
+        build_metadata: [body]
         text: |
           The build had a result. Check it out at:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME

--- a/assets/common
+++ b/assets/common
@@ -107,7 +107,7 @@ containsElement () {
 # given a string, performs token replacement for the concourse build metadata environment variables
 replaceBuildMetadata() {
   local str=$1
-  for var in BUILD_ID BUILD_NAME BUILD_JOB_NAME BUILD_PIPELINE_NAME BUILD_TEAM_NAME ATC_EXTERNAL_URL; do
+  for var in BUILD_ID BUILD_NAME BUILD_JOB_NAME BUILD_PIPELINE_NAME BUILD_TEAM_NAME BUILD_CREATED_BY ATC_EXTERNAL_URL; do
     str="${str//\$$var/${!var:-}}"
     str="${str//\$\{$var\}/${!var:-}}"
   done
@@ -119,6 +119,27 @@ replaceBuildMetadataInFile() {
   local target_file=${2:-$source_file}
   local tmp="$(cat "$target_file")"
   echo "$(replaceBuildMetadata "$tmp")" > "$target_file"
+}
+
+# given a string, determine if it is listed in our "build_metadata" for token replacement
+shouldReplaceBuildMetadataIn() {
+  local component=$1
+  if isSet params_build_metadata; then
+    if $(jq --arg COMPONENT "$component" 'any(index($COMPONENT))' <<< "$params_build_metadata"); then return 0; fi
+  elif isSet source_build_metadata; then
+    if $(jq --arg COMPONENT "$component" 'any(index($COMPONENT))' <<< "$source_build_metadata"); then return 0; fi
+  fi
+  return 1;
+}
+
+shouldReplaceBuildMetadataInHeaders() {
+  if $(shouldReplaceBuildMetadataIn "headers"); then return 0; fi
+  return 1;
+}
+
+shouldReplaceBuildMetadataInBody() {
+  if $(shouldReplaceBuildMetadataIn "body"); then return 0; fi
+  return 1;
 }
 
 # -------------------------------------------------------------------------------------
@@ -145,6 +166,7 @@ source_version_hash=$(jq -r '.source.version.hash // ""' < $payload)
 source_version_default=$(jq -r '.source.version.default // ""' < $payload)
 source_out_only=$(jq -r '.source.out_only // false' < $payload)
 source_data_binary=$(jq -r '.source.data_binary // false' < $payload)
+source_build_metadata=$(jq -r '.source.build_metadata | select(.!=null)' < $payload)
 
 # params config
 params_method=$(jq -r '.params.method // ""' < $payload)
@@ -153,3 +175,4 @@ params_strict=$(jq -r '.params.strict // false' < $payload)
 params_text=$(jq -r '.params.text // ""' < $payload)
 params_file=$(jq -r '.params.file // ""' < $payload)
 params_data_binary=$(jq -r '.params.data_binary | select(.!=null)' < $payload)
+params_build_metadata=$(jq -r '.params.build_metadata | select(.!=null)' < $payload)

--- a/assets/curlops
+++ b/assets/curlops
@@ -44,7 +44,9 @@ invokeCurl() {
 
   # headers - write them all to our temp file
   jq -r '.source.headers, .params.headers | select(. != null) | to_entries[] | "\(.key): \(.value)"' < $payload > $request_headers
-  replaceBuildMetadataInFile $request_headers
+  if shouldReplaceBuildMetadataInHeaders; then
+    replaceBuildMetadataInFile $request_headers
+  fi
   expanded_headers=("-H" "@${request_headers}")
 
   # data
@@ -56,23 +58,35 @@ invokeCurl() {
     log -p "${red}Only one of source 'file' or 'text' can be set${reset}."
     exit 1
   elif isSet params_file; then
-    replaceBuildMetadataInFile "$params_file"
     if isTrue params_data_binary || (isTrue source_data_binary && notSet params_data_binary); then
       expanded_data+=("--data-binary" "@$params_file")
     else
+      if shouldReplaceBuildMetadataInBody; then
+        replaceBuildMetadataInFile "$params_file"
+      fi
       expanded_data+=("-d" "@$params_file")
     fi
   elif isSet params_text; then
-    expanded_data+=("-d" "$(replaceBuildMetadata "$params_text")")
+    if shouldReplaceBuildMetadataInBody; then
+      expanded_data+=("-d" "$(replaceBuildMetadata "$params_text")")
+    else
+      expanded_data+=("-d" "$params_text")
+    fi
   elif isSet source_file; then
-    replaceBuildMetadataInFile "$source_file"
     if isTrue params_data_binary || (isTrue source_data_binary && notSet params_data_binary); then
       expanded_data+=("--data-binary" "@$source_file")
     else
+      if shouldReplaceBuildMetadataInBody; then
+        replaceBuildMetadataInFile "$source_file"
+      fi
       expanded_data+=("-d" "@$source_file")
     fi
   elif isSet source_text; then
-    expanded_data+=("-d" "$(replaceBuildMetadata "$source_text")")
+    if shouldReplaceBuildMetadataInBody; then
+      expanded_data+=("-d" "$(replaceBuildMetadata "$source_text")")
+    else
+      expanded_data+=("-d" "$source_text")
+    fi
   fi
 
   # other options (auth, ssl, etc)

--- a/test/check.bats
+++ b/test/check.bats
@@ -347,3 +347,32 @@ teardown() {
 
     assert_equal "${expanded_options[0]}" "--head"
 }
+
+
+@test "[check] (gh-7) build metadata substitution is disabled by default" {
+    source_check "stdin-source"
+
+    refute shouldReplaceBuildMetadataInHeaders
+    refute shouldReplaceBuildMetadataInBody
+}
+
+@test "[check] (gh-7) build metadata substitution is explicitly disabled in params" {
+    source_check "stdin-build-metadata-disabled-in-params"
+
+    refute shouldReplaceBuildMetadataInHeaders
+    refute shouldReplaceBuildMetadataInBody
+}
+
+@test "[check] (gh-7) build metadata substitution is enabled in source" {
+    source_check "stdin-build-metadata-enabled-in-source"
+
+    assert shouldReplaceBuildMetadataInHeaders
+    assert shouldReplaceBuildMetadataInBody
+}
+
+@test "[check] (gh-7) build metadata substitution is enabled in params" {
+    source_check "stdin-build-metadata-enabled-in-params"
+
+    assert shouldReplaceBuildMetadataInHeaders
+    assert shouldReplaceBuildMetadataInBody
+}

--- a/test/fixtures/stdin-build-metadata-disabled-in-params.json
+++ b/test/fixtures/stdin-build-metadata-disabled-in-params.json
@@ -1,0 +1,8 @@
+{
+  "source": {
+    "build_metadata": ["headers","body"]
+  },
+  "params": {
+    "build_metadata": []
+  }
+}

--- a/test/fixtures/stdin-build-metadata-enabled-in-params.json
+++ b/test/fixtures/stdin-build-metadata-enabled-in-params.json
@@ -1,0 +1,5 @@
+{
+  "params": {
+    "build_metadata": ["headers","body"]
+  }
+}

--- a/test/fixtures/stdin-build-metadata-enabled-in-source.json
+++ b/test/fixtures/stdin-build-metadata-enabled-in-source.json
@@ -1,0 +1,5 @@
+{
+  "source": {
+    "build_metadata": ["headers","body"]
+  }
+}

--- a/test/in.bats
+++ b/test/in.bats
@@ -343,3 +343,31 @@ teardown() {
     # includes the http response in the resource's metadata
     assert_equal "$(jq -r '. | any(.metadata[]; .name == "status" and .value == "HTTP/1.1 200 OK")' <<< "$output")" 'true'
 }
+
+@test "[in] (gh-7) build metadata substitution is disabled by default" {
+    source_in "stdin-source"
+
+    refute shouldReplaceBuildMetadataInHeaders
+    refute shouldReplaceBuildMetadataInBody
+}
+
+@test "[in] (gh-7) build metadata substitution is explicitly disabled in params" {
+    source_in "stdin-build-metadata-disabled-in-params"
+
+    refute shouldReplaceBuildMetadataInHeaders
+    refute shouldReplaceBuildMetadataInBody
+}
+
+@test "[in] (gh-7) build metadata substitution is enabled in source" {
+    source_in "stdin-build-metadata-enabled-in-source"
+
+    assert shouldReplaceBuildMetadataInHeaders
+    assert shouldReplaceBuildMetadataInBody
+}
+
+@test "[in] (gh-7) build metadata substitution is enabled in params" {
+    source_in "stdin-build-metadata-enabled-in-params"
+
+    assert shouldReplaceBuildMetadataInHeaders
+    assert shouldReplaceBuildMetadataInBody
+}

--- a/test/out.bats
+++ b/test/out.bats
@@ -323,3 +323,31 @@ teardown() {
     # it should fail
     assert_failure
 }
+
+@test "[out] (gh-7) build metadata substitution is disabled by default" {
+    source_out "stdin-source"
+
+    refute shouldReplaceBuildMetadataInHeaders
+    refute shouldReplaceBuildMetadataInBody
+}
+
+@test "[out] (gh-7) build metadata substitution is explicitly disabled in params" {
+    source_out "stdin-build-metadata-disabled-in-params"
+
+    refute shouldReplaceBuildMetadataInHeaders
+    refute shouldReplaceBuildMetadataInBody
+}
+
+@test "[out] (gh-7) build metadata substitution is enabled in source" {
+    source_out "stdin-build-metadata-enabled-in-source"
+
+    assert shouldReplaceBuildMetadataInHeaders
+    assert shouldReplaceBuildMetadataInBody
+}
+
+@test "[out] (gh-7) build metadata substitution is enabled in params" {
+    source_out "stdin-build-metadata-enabled-in-params"
+
+    assert shouldReplaceBuildMetadataInHeaders
+    assert shouldReplaceBuildMetadataInBody
+}


### PR DESCRIPTION
Prior to this, the resource would always implicitly perform build
metadata token replacements on all headers and body content (regardless
of whether the body was flagged as `data_binary` or not).

This can create unnecessary trouble for scenarios where you are working
with a large body, or if the body is binary (in which case token
replacement doesn't make sense anyways).

In this commit, we are now making the build metadata token replacement
something you must opt-in for via the `build_metadata` config. It will
no longer attempt to replace the tokens by default, and accepts a list
of any/all of the following:

* `headers` - replace any tokens configured in the `headers`.
* `body` - replace any tokens in either `file` or `text` content.

For example, to `POST` some inline `text` content and headers that use
metadata tokens:

```yaml
resources:
  - name: http-bin-post
    type: http-resource
    source:
      url: https://httpbin.org/post

jobs:
  - name: post-something
    plan:
      - put: http-bin-post
        params:
          build_metadata: [headers,body]
          headers:
            Content-Type: application/json
            X-Build-Logs: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
  	  text: |
            See build logs at $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME.
```

The `build_metadata` can also be declared in the `source` config for the
resource (which would enable it for `check` operations as well), and can
be overridden in each `get` or `put` step.

See the README for more details.

Closes #7